### PR TITLE
[tuya][dimmer] Add support for double dimmer _TZE204_zenj4lxv

### DIFF
--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -93,6 +93,7 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
     signature = {
         MODELS_INFO: [
             ("_TZE200_e3oitdyu", "TS0601"),
+            ("_TZE204_zenj4lxv", "TS0601"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0051


### PR DESCRIPTION
Attempt to allow this _TZE204_zenj4lxv TS0601 to expose entities and work on HAZ:

Fix: https://github.com/zigpy/zha-device-handlers/issues/2628